### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -1,12 +1,12 @@
 ##################################
-   L9110s library by FalconXCLi
+#  L9110s library by FalconXCLi
 ##################################
 
 L9110s	KEYWORD1
 
 motor	KEYWORD2
 forward	KEYWORD2
-backward KEYWORD2
-left KEYWORD2
-right KEYWORD2
-STOP KEYWORD2
+backward	KEYWORD2
+left	KEYWORD2
+right	KEYWORD2
+STOP	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords